### PR TITLE
Add `onDismiss` to route API

### DIFF
--- a/Sources/Stinsen/NavigationCoordinatable/NavigationCoordinatable.swift
+++ b/Sources/Stinsen/NavigationCoordinatable/NavigationCoordinatable.swift
@@ -361,7 +361,16 @@ public extension NavigationCoordinatable {
         self.popTo(-1, action)
         return self
     }
-    
+
+    @discardableResult func route<Input, Output: Coordinatable>(
+        to route: KeyPath<Self, Transition<Self, Presentation, Input, Output>>,
+        _ input: Input,
+        onDismiss: @escaping () -> ()
+    ) -> Output {
+        stack.dismissalAction[-1] = onDismiss
+        return self.route(to: route, input)
+    }
+
     @discardableResult func route<Input, Output: Coordinatable>(
         to route: KeyPath<Self, Transition<Self, Presentation, Input, Output>>,
         _ input: Input
@@ -379,7 +388,15 @@ public extension NavigationCoordinatable {
         output.parent = self
         return output
     }
-    
+
+    @discardableResult func route<Output: Coordinatable>(
+        to route: KeyPath<Self, Transition<Self, Presentation, Void, Output>>,
+        onDismiss: @escaping () -> ()
+    ) -> Output {
+        stack.dismissalAction[-1] = onDismiss
+        return self.route(to: route)
+    }
+
     @discardableResult func route<Output: Coordinatable>(
         to route: KeyPath<Self, Transition<Self, Presentation, Void, Output>>
     ) -> Output {
@@ -396,7 +413,16 @@ public extension NavigationCoordinatable {
         output.parent = self
         return output
     }
-    
+
+    @discardableResult func route<Input, Output: View>(
+        to route: KeyPath<Self, Transition<Self, Presentation, Input, Output>>,
+        _ input: Input,
+        onDismiss: @escaping () -> ()
+    ) -> Self {
+        stack.dismissalAction[-1] = onDismiss
+        return self.route(to: route, input)
+    }
+
     @discardableResult func route<Input, Output: View>(
         to route: KeyPath<Self, Transition<Self, Presentation, Input, Output>>,
         _ input: Input
@@ -413,7 +439,15 @@ public extension NavigationCoordinatable {
         )
         return self
     }
-    
+
+    @discardableResult func route<Output: View>(
+        to route: KeyPath<Self, Transition<Self, Presentation, Void, Output>>,
+        onDismiss: @escaping () -> ()
+    ) -> Self {
+        stack.dismissalAction[-1] = onDismiss
+        return self.route(to: route)
+    }
+
     @discardableResult func route<Output: View>(
         to route: KeyPath<Self, Transition<Self, Presentation, Void, Output>>
     ) -> Self {


### PR DESCRIPTION
## Add `onDismiss` to route API

Useful for when dismiss is initiated by user via a drag to dismiss on a sheet